### PR TITLE
Bump resolver from lts-16.27 to lts-17.15

### DIFF
--- a/evm-opcodes.cabal
+++ b/evm-opcodes.cabal
@@ -1,10 +1,8 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: a7a1883c6dbab096f458e526caec677a134c7c3eb94a56b5482d58ecf9b8050a
 
 name:           evm-opcodes
 version:        0.1.0
@@ -33,12 +31,12 @@ library
       src
   ghc-options: -Wall -Wnoncanonical-monad-instances -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   build-depends:
-      base >=4.12 && <4.15
-    , bytestring >=0.10 && <0.11
-    , cereal >=0.5 && <0.6
-    , containers >=0.6 && <0.7
-    , data-dword >=0.3 && <0.4
-    , text >=1.2 && <1.3
+      base >=4.12 && <4.16
+    , bytestring >=0.10 && <0.12
+    , cereal ==0.5.*
+    , containers ==0.6.*
+    , data-dword ==0.3.*
+    , text ==1.2.*
   default-language: Haskell2010
 
 test-suite test
@@ -51,11 +49,11 @@ test-suite test
   hs-source-dirs:
       test
   build-depends:
-      base >=4.12 && <4.15
-    , bytestring >=0.10 && <0.11
-    , cereal >=0.5 && <0.6
-    , containers >=0.6 && <0.7
-    , data-dword >=0.3 && <0.4
+      base >=4.12 && <4.16
+    , bytestring >=0.10 && <0.12
+    , cereal ==0.5.*
+    , containers ==0.6.*
+    , data-dword ==0.3.*
     , evm-opcodes
     , hedgehog
     , hspec
@@ -63,5 +61,5 @@ test-suite test
     , tasty-discover
     , tasty-hedgehog
     , tasty-hspec
-    , text >=1.2 && <1.3
+    , text ==1.2.*
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -15,8 +15,8 @@ extra-source-files:
   - README.md
 
 dependencies:
-  - base                        >= 4.12 && < 4.15
-  - bytestring                 ^>= 0.10
+  - base                        >= 4.12 && < 4.16
+  - bytestring                  >= 0.10 && < 0.12
   - cereal                     ^>= 0.5
   - data-dword                 ^>= 0.3
   - containers                 ^>= 0.6

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,3 @@
-resolver: lts-16.27
+resolver: lts-17.15
 packages:
   - .
-extra-deps:
-  - hedgehog-1.0.4

--- a/test/OpcodeTest.hs
+++ b/test/OpcodeTest.hs
@@ -18,6 +18,7 @@ import           Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import           Test.Tasty.Hspec
+import           Test.Hspec
 
 import EVM.Opcode as Opcode
 import EVM.Opcode.Positional as P


### PR DESCRIPTION
- Increase 'bytestring' bound.