### PR TITLE
Fix Show instances

### DIFF
--- a/evm-opcodes.cabal
+++ b/evm-opcodes.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           evm-opcodes
-version:        0.1.1
+version:        0.1.2
 synopsis:       Opcode types for Ethereum Virtual Machine (EVM)
 description:    This library provides opcode types for the Ethereum Virtual Machine.
 category:       Ethereum, Finance, Network

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:         evm-opcodes
-version:      0.1.1
+version:      0.1.2
 synopsis:     'Opcode types for Ethereum Virtual Machine (EVM)'
 description:  'This library provides opcode types for the Ethereum Virtual Machine.'
 category:     Ethereum, Finance, Network

--- a/src/EVM/Opcode.hs
+++ b/src/EVM/Opcode.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE PatternSynonyms #-}
 
 -- |
@@ -79,7 +78,6 @@ import           Data.Maybe (isJust)
 import qualified Data.Serialize.Get as Cereal
 import           Data.String (IsString, fromString)
 import           Data.Text (Text)
-import qualified Data.Text as Text
 import qualified Data.List as List
 import           Data.Word (Word8, Word64)
 import           Text.Printf (printf)
@@ -88,11 +86,6 @@ import EVM.Opcode.Internal
 
 -- | An 'Opcode' is a plain, parameterless Ethereum VM Opcode.
 type Opcode = Opcode' ()
-
--- | Show 'PUSH' as the Haskell data constructor
-instance {-# OVERLAPPING #-} Show Opcode where
-  show (PUSH n) = "PUSH " <> show n
-  show opcode = Text.unpack (Text.toUpper (opcodeText opcode))
 
 -- | 'jump' is a plain parameterless 'Opcode'.
 jump :: Opcode

--- a/src/EVM/Opcode/Internal.hs
+++ b/src/EVM/Opcode/Internal.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE LambdaCase #-}
@@ -110,7 +109,11 @@ data Opcode' j
 
   -- 60s & 70s: Push Operations
   | PUSH !Word256     -- ^ 0x60 - 0x7f (PUSH1 - PUSH32)
+
+  -- 80s: Duplication Operations (DUP)
   | DUP !Ord16         -- ^ 0x80 - 0x8f ('DUP1' - 'DUP16')
+
+  -- 90s: Exchange operations (SWAP)
   | SWAP !Ord16        -- ^ 0x90 - 0x9f ('SWAP1' - 'SWAP16')
 
   -- a0s: Logging Operations
@@ -341,13 +344,12 @@ opcodeSpec opcode = case opcode of
   INVALID      -> OpcodeSpec 0xfe 0 0 "invalid" -- α, δ are ∅
   SELFDESTRUCT -> OpcodeSpec 0xff 1 0 "selfdestruct"
 
-instance {-# OVERLAPPABLE #-} Show a => Show (Opcode' a) where
-  show opcode = show (concrete opcode) <> showParam opcode
-    where
-      showParam (JUMP a) = " " <> show a
-      showParam (JUMPI a) = " " <> show a
-      showParam (JUMPDEST a) = " " <> show a
-      showParam _opcode = ""
+instance Show a => Show (Opcode' a) where
+  show (PUSH n) = "PUSH " <> show n
+  show (JUMP j) = "JUMP " <> show j
+  show (JUMPI j) = "JUMPI " <> show j
+  show (JUMPDEST j) = "JUMPDEST " <> show j
+  show opcode = Text.unpack (Text.toUpper (opcodeName (opcodeSpec opcode)))
 
 -- | Convert the constant argument of a 'PUSH' to the opcode encoding
 -- (0x60--0x7f) and its constant split into 'Word8' segments.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 587821
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/24.yaml
-    sha256: 06d844ba51e49907bd29cb58b4a5f86ee7587a4cd7e6cf395eeec16cba619ce8
-  original: lts-18.24
+    size: 590100
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
+    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
+  original: lts-18.28

--- a/test/OpcodeTest.hs
+++ b/test/OpcodeTest.hs
@@ -92,6 +92,10 @@ spec_EVM_Opcode_Labelled = do
     it "handles empty lists" $
       L.translate [] `shouldBe` Right []
 
+    it "handles instructions without jumps" $ do
+      L.translate [STOP] `shouldBe` Right [STOP]
+      L.translate [PUSH 2, PUSH 2, ADD] `shouldBe` Right [PUSH 2, PUSH 2, ADD]
+
     it "handles empty labels" $
       L.translate [JUMP "", JUMPDEST ""] `shouldBe` Right [JUMP 3, JUMPDEST 3]
 
@@ -139,6 +143,118 @@ spec_EVM_Opcode_Labelled = do
           duplicateDests = [ "x", "y" ]
 
       in L.translate instructions `shouldBe` Left (TranslateError wildJumps duplicateDests)
+
+spec_Show_for_Opcode :: Spec
+spec_Show_for_Opcode =
+  describe "show" $ do
+    -- 0s: Stop and Arithmetic Operations
+    it "shows STOP" $ show' STOP `shouldBe` "STOP"
+    it "shows ADD" $ show' ADD `shouldBe` "ADD"
+    it "shows MUL" $ show' MUL `shouldBe` "MUL"
+    it "shows SUB" $ show' SUB `shouldBe` "SUB"
+    it "shows DIV" $ show' DIV `shouldBe` "DIV"
+    it "shows SDIV" $ show' SDIV `shouldBe` "SDIV"
+    it "shows MOD" $ show' MOD `shouldBe` "MOD"
+    it "shows SMOD" $ show' SMOD `shouldBe` "SMOD"
+    it "shows ADDMOD" $ show' ADDMOD `shouldBe` "ADDMOD"
+    it "shows MULMOD" $ show' MULMOD `shouldBe` "MULMOD"
+    it "shows EXP" $ show' EXP `shouldBe` "EXP"
+    it "shows SIGNEXTEND" $ show' SIGNEXTEND `shouldBe` "SIGNEXTEND"
+
+    -- 10s: Comparison & Bitwise Logic Operations
+    it "shows LT" $ show' LT `shouldBe` "LT"
+    it "shows GT" $ show' GT `shouldBe` "GT"
+    it "shows SLT" $ show' SLT `shouldBe` "SLT"
+    it "shows SGT" $ show' SGT `shouldBe` "SGT"
+    it "shows EQ" $ show' EQ `shouldBe` "EQ"
+    it "shows ISZERO" $ show' ISZERO `shouldBe` "ISZERO"
+    it "shows AND" $ show' AND `shouldBe` "AND"
+    it "shows OR" $ show' OR `shouldBe` "OR"
+    it "shows XOR" $ show' XOR `shouldBe` "XOR"
+    it "shows NOT" $ show' NOT `shouldBe` "NOT"
+    it "shows BYTE" $ show' BYTE `shouldBe` "BYTE"
+    it "shows SHL" $ show' SHL `shouldBe` "SHL"
+    it "shows SHR" $ show' SHR `shouldBe` "SHR"
+    it "shows SAR" $ show' SAR `shouldBe` "SAR"
+
+    -- 20s: SHA3
+    it "shows SHA3" $ show' SHA3 `shouldBe` "SHA3"
+
+    -- 30s: Environmental Information
+    it "shows ADDRESS" $ show' ADDRESS `shouldBe` "ADDRESS"
+    it "shows BALANCE" $ show' BALANCE `shouldBe` "BALANCE"
+    it "shows ORIGIN" $ show' ORIGIN `shouldBe` "ORIGIN"
+    it "shows CALLER" $ show' CALLER `shouldBe` "CALLER"
+    it "shows CALLVALUE" $ show' CALLVALUE `shouldBe` "CALLVALUE"
+    it "shows CALLDATALOAD" $ show' CALLDATALOAD `shouldBe` "CALLDATALOAD"
+    it "shows CALLDATASIZE" $ show' CALLDATASIZE `shouldBe` "CALLDATASIZE"
+    it "shows CALLDATACOPY" $ show' CALLDATACOPY `shouldBe` "CALLDATACOPY"
+    it "shows CODESIZE" $ show' CODESIZE `shouldBe` "CODESIZE"
+    it "shows CODECOPY" $ show' CODECOPY `shouldBe` "CODECOPY"
+    it "shows GASPRICE" $ show' GASPRICE `shouldBe` "GASPRICE"
+    it "shows EXTCODESIZE" $ show' EXTCODESIZE `shouldBe` "EXTCODESIZE"
+    it "shows EXTCODECOPY" $ show' EXTCODECOPY `shouldBe` "EXTCODECOPY"
+    it "shows RETURNDATASIZE" $ show' RETURNDATASIZE `shouldBe` "RETURNDATASIZE"
+    it "shows RETURNDATACOPY" $ show' RETURNDATACOPY `shouldBe` "RETURNDATACOPY"
+    it "shows EXTCODEHASH" $ show' EXTCODEHASH `shouldBe` "EXTCODEHASH"
+
+    -- 40s: Block Information
+    it "shows BLOCKHASH" $ show' BLOCKHASH `shouldBe` "BLOCKHASH"
+    it "shows COINBASE" $ show' COINBASE `shouldBe` "COINBASE"
+    it "shows TIMESTAMP" $ show' TIMESTAMP `shouldBe` "TIMESTAMP"
+    it "shows NUMBER" $ show' NUMBER `shouldBe` "NUMBER"
+    it "shows DIFFICULTY" $ show' DIFFICULTY `shouldBe` "DIFFICULTY"
+    it "shows GASLIMIT" $ show' GASLIMIT `shouldBe` "GASLIMIT"
+    it "shows CHAINID" $ show' CHAINID `shouldBe` "CHAINID"
+    it "shows SELFBALANCE" $ show' SELFBALANCE `shouldBe` "SELFBALANCE"
+
+    -- 50s: Stack, Memory, Storage and Flow Operations
+    it "shows POP" $ show' POP `shouldBe` "POP"
+    it "shows MLOAD" $ show' MLOAD `shouldBe` "MLOAD"
+    it "shows MSTORE" $ show' MSTORE `shouldBe` "MSTORE"
+    it "shows MSTORE8" $ show' MSTORE8 `shouldBe` "MSTORE8"
+    it "shows SLOAD" $ show' SLOAD `shouldBe` "SLOAD"
+    it "shows SSTORE" $ show' SSTORE `shouldBe` "SSTORE"
+    it "shows JUMP" $ show' (JUMP ()) `shouldBe` "JUMP ()"
+    it "shows JUMPI" $ show' (JUMPI ()) `shouldBe` "JUMPI ()"
+    it "shows PC" $ show' PC `shouldBe` "PC"
+    it "shows MSIZE" $ show' MSIZE `shouldBe` "MSIZE"
+    it "shows GAS" $ show' GAS `shouldBe` "GAS"
+    it "shows JUMPDEST" $ show' (JUMPDEST ()) `shouldBe` "JUMPDEST ()"
+
+    -- 60s & 70s: Push Operations
+    for_ [0, 255, 256, 65535, 65536] $ \i ->
+      it ("shows PUSH " <> show i) $ show' (PUSH i) `shouldBe` "PUSH " <> show i
+
+    -- 80s: Duplication Operations (DUP)
+    for_ [minBound..maxBound] $ \nth -> do
+      let i = fromEnum nth + 1
+      it ("shows DUP" <> show i) $ show' (DUP nth) `shouldBe` ("DUP" <> show i)
+
+    -- 90s: Exchange operations (SWAP)
+    for_ [minBound..maxBound] $ \nth -> do
+      let i = fromEnum nth + 1
+      it ("shows DUP" <> show i) $ show' (SWAP nth) `shouldBe` ("SWAP" <> show i)
+
+    -- a0s: Logging Operations (LOG)
+    for_ [minBound..maxBound] $ \nth -> do
+      let i = fromEnum nth
+      it ("shows DUP" <> show i) $ show' (LOG nth) `shouldBe` ("LOG" <> show i)
+
+    -- f0s: System Operations
+    it "shows CREATE" $ show' CREATE `shouldBe` "CREATE"
+    it "shows CALL" $ show' CALL `shouldBe` "CALL"
+    it "shows CALLCODE" $ show' CALLCODE `shouldBe` "CALLCODE"
+    it "shows RETURN" $ show' RETURN `shouldBe` "RETURN"
+    it "shows DELEGATECALL" $ show' DELEGATECALL `shouldBe` "DELEGATECALL"
+    it "shows CREATE2" $ show' CREATE2 `shouldBe` "CREATE2"
+    it "shows STATICCALL" $ show' STATICCALL `shouldBe` "STATICCALL"
+    it "shows REVERT" $ show' REVERT `shouldBe` "REVERT"
+    it "shows INVALID" $ show' INVALID `shouldBe` "INVALID"
+    it "shows SELFDESTRUCT" $ show' SELFDESTRUCT `shouldBe` "SELFDESTRUCT"
+  where
+    show' :: Opcode -> String
+    show' = show
 
 shouldMissErr :: (Show b, Eq b) => Either TranslateError b -> [Label] -> Expectation
 shouldMissErr x y = x `shouldBe` Left (TranslateError y [])


### PR DESCRIPTION
The following instance causes infinite recursion for `Opcode' ()`, since
`concrete = void`, i.e. `show opcode` becomes `show (concrete opcode)`
becomes `show (show (concrete opcode))`, etc. ad infinitum.

```haskell
-instance {-# OVERLAPPABLE #-} Show a => Show (Opcode' a) where
-  show opcode = show (concrete opcode) <> showParam opcode
```

The overlapping instance for `Opcode' ()` was supposed to have been the
base case for this recursion, but it apparently never triggered. Because
the Show instance was not tested, and the test suite only uses the Show
instance when there are errors, an error was not caused for a long time,
since the only updates have been version bumps since the regression.

- Remove FlexibleInstances
- Remove OVERLAPPING instances for Show
- Remove orphan instance for Opcode' ()
- Test `show` for `Opcode' ()`

This fixes #3.

Bump evm-opcodes to v0.1.2.